### PR TITLE
Use Thinlinc 4.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV UBUNTU_RELEASE=${UBUNTU_RELEASE}
 STOPSIGNAL SIGRTMIN+3
 COPY build /build
 RUN cd /build; sh start.sh
-RUN curl https://www.cendio.com/downloads/server/tl-4.17.0-server.zip > tl.zip; unzip tl.zip;rm tl.zip; cd tl-*-server/packages;rm *rpm *_i386.deb;dpkg --install *.deb; cd /;rm -rf /tl-*-server; /opt/thinlinc/sbin/tl-setup -a /build/tl-setup-answers; rm -rf /build
+RUN curl https://www.cendio.com/downloads/server/tl-4.18.0-server.zip > tl.zip; unzip tl.zip;rm tl.zip; cd tl-*-server/packages;rm *rpm *_i386.deb;dpkg --install *.deb; cd /;rm -rf /tl-*-server; /opt/thinlinc/sbin/tl-setup -a /build/tl-setup-answers; rm -rf /build
 #RUN curl https://www.cendio.com/downloads/beta/tl-4.13.0beta1-server.zip > tl.zip; unzip tl.zip;rm tl.zip; cd tl-*-server/packages;rm *rpm *_i386.deb;dpkg --install *.deb; cd /;rm -rf /tl-*-server; /opt/thinlinc/sbin/tl-setup -a /build/tl-setup-answers; rm -rf /build
 # when the image actually runs, then systemd will be runnnig
 # so put things in order again ...

--- a/build/tl-setup-answers
+++ b/build/tl-setup-answers
@@ -1,16 +1,63 @@
-install-pygtk=yes
-email-address=root@localhost
-setup-selinux=no
-setup-nearest=no
-server-type=master
-setup-firewall=no
-install-python-ldap=yes
-setup-apparmor=no
-missing-answer=abort
-install-nfs=yes
-setup-thinlocal=no
-install-sshd=no
-tlwebadm-password=RH0KnE6efAOWQLiLRzrVaif9BxnZ1V6GwJMY9nNQvg95rNhSJRgOf.ej42J3xM.oLNzmyfbBeQrzU/HgPEXoh.
+# To generate a template for this file, run:
+# /opt/thinlinc/sbin/tl-setup --generate-answers=THIS-FILE
+# Then edit the file to suit your system.
+    
+# ThinLinc tl-setup answers file
+#
+# Edit this file to suit your systems and run:
+#  /opt/thinlinc/sbin/tl-setup -a THIS-FILE
+
+# Accept the end user license agreement
 accept-eula=yes
+
+# Configure as master or agent
+server-type=master
+
+# How should old Hiveconf files be handled?
 migrate-conf=ignore
+
+# Install required libraries and binaries?
 install-required-libs=yes
+
+# Install NFS client packages?
+install-nfs=yes
+
+# Install OpenSSH server?
+install-sshd=no
+
+# Install GTK+ and PyGObject packages?
+install-gtk=yes
+
+# Install python-ldap packages?
+install-python-ldap=yes
+
+# How to determine externally reachable hostname
+agent-hostname-choice=ip
+
+# Externally reachable hostname (only used if manual)
+#manual-agent-hostname=<hostname>
+
+# Send administrative messages to:
+email-address=root@localhost
+
+# Password for tlwebadm (generate with "/opt/thinlinc/sbin/tl-gen-auth"):
+tlwebadm-password=$6$757a34323677b435$CWY4/cvYryY/uD7UsQ/kKNqoRkCMiMRgQf1hvih6JZehP1/bMbWWJiMUIoUGSGkSkJJvwPjfMuhZZzzeJ7gka1
+
+# Set up the thinlocal printing queue?
+setup-thinlocal=no
+
+# Set up the nearest printing queue?
+setup-nearest=no
+
+# Configure the local firewall for ThinLinc services?
+setup-firewall=no
+
+# Set up SELinux policy module?
+setup-selinux=no
+
+# Set up AppArmor configuration?
+setup-apparmor=no
+
+# What should tl-setup do when it encounters a question without a matching answer in the answer file?
+missing-answer=abort
+


### PR DESCRIPTION
 I had the same problem as @williamsjoblom mentioned in [this issue](https://github.com/oposs/tl-docker/issues/8). I changed Thinlinc for 4.18.0. I ran the following command to get an answers template file. Then I edited it.

`/opt/thinlinc/sbin/tl-setup --generate-answers=tl-setup-answers`

This is what I've done to test the modifications.

Build the image (everything OK):
docker build --no-cache -t test/tl-ubuntu .

Start the container (some fails see below):
docker run --privileged --name my-tl-demo2 --publish 9922:22 -t test/tl-ubuntu
I saw the following failed messages in the listing,  but every thing seems to be working fine. Maybe I made some wrong choices in the tl-setup-answers file. Maybe @oetiker can review and correct this.

```
[DEPEND] Dependency failed for SSSD NSS Service responder socket.
[DEPEND] Dependency failed for SSSD AutoFS Service responder socket.
[DEPEND] Dependency failed for SSSD PAC Service responder socket.
[DEPEND] Dependency failed for SSSD PAM Service responder private socket.
[DEPEND] Dependency failed for SSSD PAM Service responder socket.
[DEPEND] Dependency failed for SSSD SSH Service responder socket.
[DEPEND] Dependency failed for SSSD Sudo Service responder socket.
```
`docker exec my-tl-demo2 tlcfg add-user guest ChangeMe`
`docker exec my-tl-demo2 tlcfg set-hostname 127.0.0.1`

Then stated Thinlinc Client and it ran fine.